### PR TITLE
Incorrect key for containerWidth. It should be containerMaxWidth

### DIFF
--- a/src/components/theme-setup/ContainerGutterWidth.js
+++ b/src/components/theme-setup/ContainerGutterWidth.js
@@ -12,7 +12,7 @@ import {
 
 const theme = {
   grid: {
-    containerWidth: {
+    containerMaxWidth: {
         xs: "540px",
         sm: "720px",
         md: "960px",


### PR DESCRIPTION
Incorrect example code for customizing containerWidth. It should be containerMaxWidth.